### PR TITLE
fix(aws-frontend): graceful removal of deployment

### DIFF
--- a/modules/aws-frontend/variables.tf
+++ b/modules/aws-frontend/variables.tf
@@ -97,3 +97,9 @@ variable "lambda_log_retention_in_days" {
   default     = 14
   description = "CloudWatch log rentention time for Lambda@Edge functions."
 }
+
+variable "scheduled_for_deletion" {
+  type        = bool
+  default     = false
+  description = "Enable this to disconnect Lambda@Edge functions from CloudFront distribution and enables force_Destroy on S3 bucket. It's necessary to proceed with module deletion."
+}

--- a/modules/vault-group/policy-templates/db-write.hcl
+++ b/modules/vault-group/policy-templates/db-write.hcl
@@ -6,7 +6,7 @@ path "${engine_path}/roles/${group_name}${separator}${environment}${separator}+"
   capabilities = ["create", "delete"]
 }
 
-# Create and delete roles
+# Rotate roles
 path "${engine_path}/rotate-role/${group_name}${separator}${environment}${separator}+" {
   capabilities = ["create"]
 }


### PR DESCRIPTION
AWS doesn't let us remove Lambda functions which are bound to CloudFront. I added a flag which removes Lambda attachment, so we could deprovision `aws-frontend` module only by using Terraform. It still takes 2 `apply`s and couple of hours, but it's better than resorting to manual actions in AWS Console. Second improvement is related to S3 bucket, which can now be forcefully removed.