### PR TITLE
fix(vault-group): add missing read-write policies

### DIFF
--- a/modules/vault-group/example/main.tf
+++ b/modules/vault-group/example/main.tf
@@ -36,13 +36,13 @@ module "sales_groups" {
     # This group has full access to Sales dev env
     non_prod = {
       entities     = var.non_prod_access
-      policies     = ["read", "write"]
+      policies     = ["read-write"]
       environments = ["dev"]
     }
     # This group has full access to Sales dev and prod envs
     prod = {
       entities     = var.prod_access
-      policies     = ["read", "write"]
+      policies     = ["read-write"]
       environments = ["dev", "prod"]
     }
   }
@@ -61,7 +61,7 @@ module "internal_groups" {
     # Note that they're all based on the same "non_prod" secret engines and we don't have to redefine anything
     dev = {
       entities     = var.non_prod_access
-      policies     = ["read", "write"]
+      policies     = ["read-write"]
       environments = ["local", "dev", "staging", "test", "demo"]
     }
     # This group has read-only access to Internal prod env

--- a/modules/vault-group/main.tf
+++ b/modules/vault-group/main.tf
@@ -14,27 +14,53 @@
  *
  * As a result, you get the following:
  * * Vault Policies:
- *     - `sales/dev-read` (can read secrets in paths: `/kv/sales/dev`, `/rabbitmq/sales/dev`, `/mongodb/sales/dev`)
- *     - `sales/dev-write` (can write secrets in paths: `/kv/sales/dev`, `/rabbitmq/sales/dev`, `/mongodb/sales/dev`)
- *     - `sales/prod-read` (can read secrets in paths: `/kv/sales/prod`, `/rabbitmq/sales/prod`, `/mongodb/sales/prod`)
- *     - `sales/prod-write` (can write secrets in paths: `/kv/sales/prod`, `/rabbitmq/sales/prod`, `/mongodb/sales/prod`)
- *     - `internal/dev-read` (can read secrets in paths: `/kv/internal/dev`)
- *     - `internal/dev-write` (can write secrets in paths: `/kv/internal/dev`)
- *     - `internal/local-read` (can read secrets in paths: `/kv/internal/local`)
- *     - `internal/local-write` (can write secrets in paths: `/kv/internal/local`)
- *     - `internal/test-read` (can read secrets in paths: `/kv/internal/test`)
- *     - `internal/test-write` (can write secrets in paths: `/kv/internal/test`)
- *     - `internal/staging-read` (can read secrets in paths: `/kv/internal/staging`)
- *     - `internal/staging-write` (can write secrets in paths: `/kv/internal/staging`)
- *     - `internal/demo-read` (can read secrets in paths: `/kv/internal/demo`)
- *     - `internal/demo-write` (can write secrets in paths: `/kv/internal/demo`)
- *     - `internal/prod-read` (can read secrets in paths: `/kv/internal/prod`)
- *     - `internal/prod-read` (can write secrets in paths: `/kv/internal/prod`)
+ *     - for paths: `/kv/sales/dev`, `/rabbitmq/sales/dev`, `/mongodb/sales/dev`:
+ *        - `sales/dev-read`,
+ *        - `sales/dev-read-write`
+ *        - `sales/dev-write`
+ *     - for paths: `/kv/sales/prod`, `/rabbitmq/sales/prod`, `/mongodb/sales/prod`:
+ *        - `sales/prod-read`
+ *        - `sales/prod-read-write`
+ *        - `sales/prod-write`
+ *     - for path `/kv/internal/dev`:
+ *       - `internal/dev-read`
+ *       - `internal/dev-read-write`
+ *       - `internal/dev-write`
+ *     - for path `/kv/internal/local`:
+ *       - `internal/local-read`
+ *       - `internal/local-read-write`
+ *       - `internal/local-write`
+ *     - for path `/kv/internal/test`:
+ *       - `internal/test-read`
+ *       - `internal/test-read-write`
+ *       - `internal/test-write`
+ *     - for path `/kv/internal/staging`:
+ *       - `internal/staging-read`
+ *       - `internal/staging-read-write`
+ *       - `internal/staging-write`
+ *     - for path `/kv/internal/demo`:
+ *       - `internal/demo-read`
+ *       - `internal/demo-read-write`
+ *       - `internal/demo-write`
+ *     - for path `/kv/internal/prod`:
+ *       - `internal/prod-read`
+ *       - `internal/prod-read-write`
+ *       - `internal/prod-write`
  * * Vault Groups:
- *     - `sales/non-prod` (with policies: `sales/dev-read`, `sales/dev-write`)
- *     - `sales/prod` (with policies: `sales/dev-read`, `sales/dev-write`, `sales/prod-read`, `sales/prod-write`)
- *     - `internal/dev` (with policies: `internal/dev-read`, `internal/dev-write`, `internal/local-read`, `internal/local-write`, `internal/staging-read`, `internal/staging-write`, `internal/test-read`, `internal/test-write`, `internal/demo-read`, `internal/demo-write`)
- *     - `internal/prod` (with policy: `internal/prod-read`)
+ *     - `sales/non-prod` with policies:
+ *       - `sales/dev-read-write`
+ *       - `sales/dev-write`
+ *     - `sales/prod` with policies:
+ *       - `sales/dev-read-write`
+ *       - `sales/prod-read-write`
+ *     - `internal/dev` with policies:
+ *       - `internal/dev-read-write`
+ *       - `internal/local-read-write`
+ *       - `internal/staging-read-write`
+ *       - `internal/test-read-write`
+ *       - `internal/demo-read-write`
+ *     - `internal/prod` with policy:
+ *       - `internal/prod-read`
  * * Entities you passed to specific groups are added to these Vault Groups.
  *
  * As you can see in this complex example, you only type name of a group (aka namespace, aka prefix), environments, policies and you get a matrix of policies, groups and group attachments done for you. You don't have to worry about writing policies directly, as templates handle that for you automatically. It scales really well and helps in making configurations DRY, yet still extendable.
@@ -44,7 +70,7 @@
  *
  * ## Supported Secret Engines
  *
- * Most secret engines have different paths and need different permissions, so in order to support them we use read and write policy templates. You can inspect them in [policy-templates](./policy-templates) directory.
+ * Most secret engines have different paths and need different permissions, so in order to support them we use `read`, `read-write` and `write` policy templates. You can inspect them in [policy-templates](./policy-templates) directory.
  *
  * * Key-Value Version 2 (name: `kv2`)
  * * Database (name: `db`)
@@ -59,7 +85,7 @@ locals {
   # Policy data contain everything needed for templates to be inflated
   policy_data = flatten([
     for environment, secret_engines in var.environments : [
-      for policy in ["read", "write"] : [
+      for policy in ["read", "read-write", "write"] : [
         for key, data in secret_engines : {
           type        = "${data[0]}-${policy}"
           key         = "${environment}-${key}/${policy}"

--- a/modules/vault-group/policy-templates/aws-read-write.hcl
+++ b/modules/vault-group/policy-templates/aws-read-write.hcl
@@ -1,0 +1,21 @@
+# AWS Secret Engine Policy
+# Allows Full Read-Write Access
+
+# List roles
+path "${engine_path}/roles" {
+  capabilities = ["list"]
+}
+
+# Read, write and delete roles
+path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read", "create", "delete"]
+}
+
+# Generate credentials
+path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read"]
+}
+
+path "${engine_path}/sts/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read"]
+}

--- a/modules/vault-group/policy-templates/db-read-write.hcl
+++ b/modules/vault-group/policy-templates/db-read-write.hcl
@@ -1,0 +1,37 @@
+# Database Secret Engine Policy
+# Allows Full Read-Write Access
+
+# List roles
+path "${engine_path}/roles" {
+  capabilities = ["list"]
+}
+
+# Create, read and delete roles
+path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read", "create", "delete"]
+}
+
+# List static roles
+path "${engine_path}/static-roles" {
+  capabilities = ["list"]
+}
+
+# Read, create and delete static roles
+path "${engine_path}/static-roles/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read", "create", "delete"]
+}
+
+# Rotate roles
+path "${engine_path}/rotate-role/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["create"]
+}
+
+# Generate credentials
+path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read"]
+}
+
+# Read static credentials
+path "${engine_path}/static-creds/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read"]
+}

--- a/modules/vault-group/policy-templates/kv2-read-write.hcl
+++ b/modules/vault-group/policy-templates/kv2-read-write.hcl
@@ -1,0 +1,45 @@
+# KV (Version 2) Secret Engine Policy
+# Allows Full Read-Write Access
+
+# View metadata, list keys
+path "${engine_path}/metadata/${group_name}/${environment}/*" {
+  capabilities = ["list"]
+}
+
+path "${engine_path}/metadata/${group_name}" {
+  capabilities = ["list"]
+}
+
+path "${engine_path}/metadata" {
+  capabilities = ["list"]
+}
+
+# Create, read, update and delete keys
+path "${engine_path}/data/${group_name}/${environment}/*"
+{
+  capabilities = ["read", "create", "update", "delete"]
+}
+
+# Mark a key version as deleted
+path "${engine_path}/delete/${group_name}/${environment}/*"
+{
+  capabilities = ["update"]
+}
+
+# Undelete a key version
+path "${engine_path}/undelete/${group_name}/${environment}/*"
+{
+  capabilities = ["update"]
+}
+
+# Delete a key version forever
+path "${engine_path}/destroy/${group_name}/${environment}/*"
+{
+  capabilities = ["update"]
+}
+
+# View & edit metadata, list keys
+path "${engine_path}/metadata/${group_name}/${environment}/*"
+{
+  capabilities = ["read", "delete"]
+}

--- a/modules/vault-group/policy-templates/rabbitmq-read-write.hcl
+++ b/modules/vault-group/policy-templates/rabbitmq-read-write.hcl
@@ -1,0 +1,12 @@
+# RabbitMQ Secret Engine Policy
+# Allows Full Read-Write Access
+
+# Read, create and delete roles
+path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read", "create", "delete"]
+}
+
+# Generate credentials
+path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
Vault does not merge permissions in given policies, so we have to explicitly specify all capabilities in `read-write` policies, as using `read` and `write` policies separately results in `read` permissions only.