### PR TITLE
fix(vault-group): allow for base-name-only roles

### DIFF
--- a/modules/vault-group/policy-templates/aws-read.hcl
+++ b/modules/vault-group/policy-templates/aws-read.hcl
@@ -7,15 +7,15 @@ path "${engine_path}/roles" {
 }
 
 # Read roles
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
 # Generate credentials
-path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/creds/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
-path "${engine_path}/sts/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/sts/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }

--- a/modules/vault-group/policy-templates/aws-write.hcl
+++ b/modules/vault-group/policy-templates/aws-write.hcl
@@ -1,6 +1,6 @@
 # Database Secret Engine Policy
 # Allows Write Access
 
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["create", "update", "delete"]
 }

--- a/modules/vault-group/policy-templates/db-read.hcl
+++ b/modules/vault-group/policy-templates/db-read.hcl
@@ -7,7 +7,7 @@ path "${engine_path}/roles" {
 }
 
 # Read roles
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
@@ -16,16 +16,16 @@ path "${engine_path}/static-roles" {
   capabilities = ["list"]
 }
 # Read static roles
-path "${engine_path}/static-roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/static-roles/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
 # Generate credentials
-path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/creds/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
 # Read static credentials
-path "${engine_path}/static-creds/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/static-creds/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }

--- a/modules/vault-group/policy-templates/db-write.hcl
+++ b/modules/vault-group/policy-templates/db-write.hcl
@@ -2,16 +2,16 @@
 # Allows Write Access
 
 # Create and delete roles
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["create", "update", "delete"]
 }
 
 # Rotate roles
-path "${engine_path}/rotate-role/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/rotate-role/${group_name}${separator}${environment}*" {
   capabilities = ["create"]
 }
 
 # Create and delete static roles
-path "${engine_path}/static-roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/static-roles/${group_name}${separator}${environment}*" {
   capabilities = ["create", "update", "delete"]
 }

--- a/modules/vault-group/policy-templates/rabbitmq-read.hcl
+++ b/modules/vault-group/policy-templates/rabbitmq-read.hcl
@@ -2,11 +2,11 @@
 # Allows Read Access
 
 # Read roles
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }
 
 # Generate credentials
-path "${engine_path}/creds/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/creds/${group_name}${separator}${environment}*" {
   capabilities = ["read"]
 }

--- a/modules/vault-group/policy-templates/rabbitmq-write.hcl
+++ b/modules/vault-group/policy-templates/rabbitmq-write.hcl
@@ -2,6 +2,6 @@
 # Allows Write Access
 
 # Create and delete roles
-path "${engine_path}/roles/${group_name}${separator}${environment}${separator}*" {
+path "${engine_path}/roles/${group_name}${separator}${environment}*" {
   capabilities = ["create", "update", "delete"]
 }


### PR DESCRIPTION
Currently, for given db/aws/rabbit engine, product and env, one can only create a role named `engine/product-env-something`.
This commit makes it possible to also create roles named `engine/product-env` (without any suffix).