### PR TITLE
fix(aws-fronted): cors headers lambda

### DIFF
--- a/modules/aws-frontend/lambda-functions/headers.js
+++ b/modules/aws-frontend/lambda-functions/headers.js
@@ -15,9 +15,8 @@ for (const key in Header) {
 }
 
 const contentSecurityPolicyHeader = Object.entries(JSON.parse(`${csp_json_string}`))
-  .map(([key, value]) => {
-    `$${key} $${value}`;
-  }).join('; ');
+  .map(([key, value]) => `$${key} $${value}`)
+  .join('; ');
 
 const headerOverrides = JSON.parse(`${custom_headers_json_string}`) || {};
 


### PR DESCRIPTION
Simple syntax bug in lambda caused no cors header being set.